### PR TITLE
Allow trailing comma after condition entries

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -28,7 +28,7 @@
       <ins>`export` ExportFromClause FromClause IfClause `;`</ins>
 
     IfClause :
-      <ins>`if` `{` ConditionEntries `}` `;`</ins>
+      <ins>`if` `{` ConditionEntries `,`? `}` `;`</ins>
 
     ConditionEntries :
       <ins>IdentifierName `:` StringLiteral</ins>

--- a/spec.html
+++ b/spec.html
@@ -35,7 +35,7 @@
       <ins>IdentifierName `:` StringLiteral `,` ConditionEntries</ins>
 
     ImportCall[Yield, Await] :
-      `import` `(` AssignmentExpression[+In, ?Yield, ?Await] `,`? `)`
+      `import` `(` AssignmentExpression[+In, ?Yield, ?Await] <ins>`,`?</ins> `)`
       <ins>`import` `(` AssignmentExpression[+In, ?Yield, ?Await] `,` AssignmentExpression[+In, ?Yield, ?Await] `,`? `)`</ins>
   </emu-grammar>
 </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -28,7 +28,7 @@
       <ins>`export` ExportFromClause FromClause IfClause `;`</ins>
 
     IfClause :
-      <ins>`if` `{` ConditionEntries `,`? `}` `;`</ins>
+      <ins>`if` `{` ConditionEntries `,`? `}`</ins>
 
     ConditionEntries :
       <ins>IdentifierName `:` StringLiteral</ins>
@@ -364,7 +364,7 @@
 
   <emu-clause id="sec-if-clause-early-errors">
     <h1>Static Semantics: Early Errors</h1>
-    <emu-grammar>IfClause : `if` ConditionEntries</emu-grammar>
+    <emu-grammar>IfClause : `if` `{` ConditionEntries `,`? `}`</emu-grammar>
     <ul>
       <li>It is a Syntax Error if IfClauseToConditions of |IfClause| has two entries _a_ and _b_ such that _a_.[[Key]] is _b_.[[Key]].</li>
     </ul>
@@ -372,7 +372,7 @@
 
   <emu-clause id="sec-if-clause-to-object" aoid="IfClauseToConditions">
     <h1>Runtime Semantics: IfClauseToConditions</h1>
-    <emu-grammar>IfClause : `if` ConditionEntries</emu-grammar>
+    <emu-grammar>IfClause : `if` `{` ConditionEntries `,`? `}`</emu-grammar>
     <emu-alg>
       1. Let _conditions_ be IfEntriesToConditions of |ConditionEntries|.
       1. Sort _conditions_ by the code point order of the [[Key]] of each entry.  NOTE: This sorting is observable only in that hosts are prohibited from distinguishing among conditions by the order they occur in.


### PR DESCRIPTION
The README mentions that
> The if syntax in the ImportDeclaration statement uses curly braces ... [because] JavaScript developers are already used to the Object literal syntax and since it allows a trailing comma copy/pasting conditions will be easy.

I expect trailing comma after condition entries is allowed and this should be reflected on the spec text.

The second commit is editorial changes.