### PR TITLE
Make name match for recursive calls to IfClauseToConditions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -383,7 +383,7 @@
     </ul>
   </emu-clause>
 
-  <emu-clause id="sec-if-clause-to-object" aoid="IfClauseToConditions">
+  <emu-clause id="sec-if-clause-to-conditions" aoid="IfClauseToConditions">
     <h1>Runtime Semantics: IfClauseToConditions</h1>
     <emu-grammar>IfClause : `if` `{` ConditionEntries `,`? `}`</emu-grammar>
     <emu-alg>
@@ -629,7 +629,7 @@
         </emu-grammar>
         <emu-alg>
           1. <ins>Let _specifier_ be StringValue of the |StringLiteral| contained in |FromClause|.</ins>
-          1. <ins>Let _conditions_ be IfClauseToObject of |IfClause|.</ins>
+          1. <ins>Let _conditions_ be IfClauseToConditions of |IfClause|.</ins>
           1. <ins>Return a ModuleRequest Record { [[Specifer]]: _specifier_, [[Conditions]]: _conditions_ }.</ins>
         </emu-alg>
         <emu-grammar>

--- a/spec.html
+++ b/spec.html
@@ -387,7 +387,7 @@
     <h1>Runtime Semantics: IfClauseToConditions</h1>
     <emu-grammar>IfClause : `if` `{` ConditionEntries `,`? `}`</emu-grammar>
     <emu-alg>
-      1. Let _conditions_ be IfEntriesToConditions of |ConditionEntries|.
+      1. Let _conditions_ be IfClauseToConditions of |ConditionEntries|.
       1. Sort _conditions_ by the code point order of the [[Key]] of each entry.  NOTE: This sorting is observable only in that hosts are prohibited from distinguishing among conditions by the order they occur in.
       1. Return _conditions_.
     </emu-alg>
@@ -401,7 +401,7 @@
     <emu-grammar> ConditionEntries : IdentifierName `:` StringLiteral `,` ConditionEntries </emu-grammar>
     <emu-alg>
       1. Let _entry_ be a Record { [[Key]]: StringValue of |IdentifierName|, [[Value]]: StringValue of |StringLiteral| }.
-      1. Let _rest_ be IfEntriesToConditions of |ConditionEntries|.
+      1. Let _rest_ be IfClauseToConditions of |ConditionEntries|.
       1. Return a new List containing _entry_ followed by the entries of _rest_.
     </emu-alg>
   </emu-clause>


### PR DESCRIPTION
Fix `IfClauseToConditions`'s recursive invocations that used the wrong name.  